### PR TITLE
Fix license consistency: Update Cargo.toml to GPL-3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rust-research-mcp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Your Name <your.email@example.com>"]
 description = "A Rust-based Model Context Protocol (MCP) server for academic research paper access"
-license = "MIT"
+license = "GPL-3.0"
 repository = "https://github.com/yourusername/rust-research-mcp"
 keywords = ["mcp", "academic", "papers", "research", "library"]
 categories = ["command-line-utilities", "science"]


### PR DESCRIPTION
- Changed license field from MIT to GPL-3.0 in Cargo.toml
- Ensures consistency with LICENSE file (GPL-3.0)
- Bumped version to 0.2.1 for checkpoint

🤖 Generated with [Claude Code](https://claude.ai/code)